### PR TITLE
Improved time management by measuring real-time clock instead of CPU-time clock

### DIFF
--- a/position.h
+++ b/position.h
@@ -8,6 +8,7 @@ typedef unsigned long long U64;
 #define WHITE 1
 #define BLACK 0
 #define MATE_SCORE 9999
+#define NO_SCORE 10000
 
 struct position {
 	U64 pieces[6];


### PR DESCRIPTION
Raven was using the clock() function to measure the spent time in search: unfortunately, this function is imprecise, as it measures CPU-time consumed rather than real-time consumed (with a core being used by several processes at the same time, sometimes the real-time is 100 ms and the CPU-time only shows 70 ms). This probably lead to the time losses Raven was suffering about in version 1.0, after tweaking the time management.

This patch changes the code by using the clock_gettime() function, very reliable to measure real time consumption, and potentially allow the re-enabling of the new time management system for Raven.